### PR TITLE
Fix typo in example Playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Example Playbook
 
     - hosts: localhost
       roles:
-        - role: ome.iptables-raw
+        - role: ome.iptables_raw
 
       tasks:
         # Block all incoming connections apart from ssh


### PR DESCRIPTION
Fixed a typo which caused an error when trying to execute the example playbook because the name of this role contains a `_` not a `-` [on Ansible Galaxy](https://galaxy.ansible.com/ome/iptables_raw/).